### PR TITLE
Add a sync button to the WordPress admin menu

### DIFF
--- a/wp-content/plugins/vinttro2.0/deployment-functions.php
+++ b/wp-content/plugins/vinttro2.0/deployment-functions.php
@@ -1,3 +1,4 @@
+<?php
 add_action('admin_menu', 'add_sync_button_to_menu');
 
 function add_sync_button_to_menu() {


### PR DESCRIPTION
Introduce a sync button in the WordPress admin menu to enhance user functionality.